### PR TITLE
Adding a package directive to make the proto-file work with rust

### DIFF
--- a/extension/proto/extension.proto
+++ b/extension/proto/extension.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 import "k8s.io/api/core/v1/generated.proto";
 
 option go_package = "extension/protogen;protogen";
+package extension;
 
 enum ValidationType {
   CREATE = 0;


### PR DESCRIPTION
Don't know if this would affect the Go build in any negative way, but I don't think so.